### PR TITLE
Do not apply breaking change in libc 0.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ extern crate libc; // this pulls in 0.3 as per Cargo.toml
 
 pub use libc::c_void;
 
-pub const EVFILT_AIO: uint32_t = 2;
+pub const EVFILT_AIO: int32_t = 2;
 ```
 
 This way we avoid the problem of having two `c_void` types that look the same


### PR DESCRIPTION
In the current Readme, the versions 0.2.1 and 0.3.0 of libc are basically identical.
I think version 0.2.1 is supposed to keep the `int32_t` type, as in version 0.2.0, to avoid any breaking change.